### PR TITLE
Fix bug in move constructor.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,16 @@
+2020-11-07  Trevor Hickey  <TrevorJamesHickey@gmail.com>
+
+	* Release 3.17
+
+	* Fix error in move constructor which caused tree
+	corruption (similar bug from 3.16).
+
 2020-11-07  Kasper Peeters  <kasper.peeters@phi-sci.com>
 
 	* Release 3.16
 
 	* Fix error in move assignment operator which caused tree
-	corruptioin (thanks to Trevor Hickey for reporting the bug).
+	corruption (thanks to Trevor Hickey for reporting the bug).
 
 2020-10-26  Kasper Peeters  <kasper.peeters@phi-sci.com>
 

--- a/src/tree.hh
+++ b/src/tree.hh
@@ -9,7 +9,7 @@
 
 /** \mainpage tree.hh
     \author   Kasper Peeters
-    \version  3.16
+    \version  3.17
     \date     07-Nov-2020
     \see      http://tree.phi-sci.com/
     \see      http://github.com/kpeeters/tree.hh/
@@ -575,7 +575,7 @@ tree<T, tree_node_allocator>::tree(tree<T, tree_node_allocator>&& x)
 	head_initialise_();
 	if(x.head->next_sibling!=x.feet) { // move tree if non-empty only
 		head->next_sibling=x.head->next_sibling;
-		feet->prev_sibling=x.head->prev_sibling;
+		feet->prev_sibling=x.feet->prev_sibling;
 		x.head->next_sibling->prev_sibling=head;
 		x.feet->prev_sibling->next_sibling=feet;
 		x.head->next_sibling=x.feet;


### PR DESCRIPTION
Thanks so much for fixing move assignment (https://github.com/kpeeters/tree.hh/issues/4 / https://github.com/kpeeters/tree.hh/commit/8dc57bc2bb7cd2fd1d6e777c6b5b58db0c3852ef).  
I believe the same must be done for the move constructor.