### PR TITLE
remove extra semicolons (-Wextra-semi)

### DIFF
--- a/src/tree.hh
+++ b/src/tree.hh
@@ -86,7 +86,7 @@ class navigation_error : public std::logic_error {
 //			std::cerr << boost::stacktrace::stacktrace() << std::endl;
 //			str << boost::stacktrace::stacktrace();
 //			stacktrace=str.str();
-			};
+			}
 
 //		virtual const char *what() const noexcept override
 //			{
@@ -503,7 +503,7 @@ class tree {
 		template<class StrictWeakOrdering>
 		class compare_nodes {
 			public:
-				compare_nodes(StrictWeakOrdering comp) : comp_(comp) {};
+				compare_nodes(StrictWeakOrdering comp) : comp_(comp) {}
 				
 				bool operator()(const tree_node *a, const tree_node *b) 
 					{


### PR DESCRIPTION
clang warnings:
```
external/tree/src/tree.hh:89:5: warning: extra ';' after member function definition [-Wextra-semi]
                        };
                         ^
external/tree/src/tree.hh:506:60: warning: extra ';' after member function definition [-Wextra-semi]
                                compare_nodes(StrictWeakOrdering comp) : comp_(comp) {};
```