### PR TITLE
Make comparison const to fix clang c++ warning

### DIFF
--- a/src/tree.hh
+++ b/src/tree.hh
@@ -505,7 +505,7 @@ class tree {
 			public:
 				compare_nodes(StrictWeakOrdering comp) : comp_(comp) {}
 				
-				bool operator()(const tree_node *a, const tree_node *b) 
+				bool operator()(const tree_node *a, const tree_node *b) const
 					{
 					return comp_(a->data, b->data);
 					}


### PR DESCRIPTION
In the standard library implementation that comes with the clang toolchain on macOS, there is a `static_assert` that checks for constness in the given multiset's comparator `operator()` implementation. This gets triggered before, when used indirectly, e.g. using the `sort` member function of `tree<>` with a lambda comparison argument. The warning is fixed by adding the `const` keyword.